### PR TITLE
A patch to make perf working with new quickfix-go API

### DIFF
--- a/outbound/main.go
+++ b/outbound/main.go
@@ -1,14 +1,17 @@
 package main
 
 import (
+	// Standard libraries
 	"flag"
+	"log"
+	"os"
+	"time"
+
+	// Custom libraries
 	"github.com/quickfixgo/quickfix"
 	"github.com/quickfixgo/quickfix/fix/enum"
 	"github.com/quickfixgo/quickfix/fix/field"
 	"github.com/quickfixgo/quickfix/fix42/newordersingle"
-	"log"
-	"os"
-	"time"
 )
 
 var fixconfig = flag.String("fixconfig", "outbound.cfg", "FIX config file")
@@ -31,12 +34,15 @@ func main() {
 		log.Fatal(err)
 	}
 
-	logFactory, err := quickfix.NewFileLogFactory(appSettings)
+	// logFactory, err := quickfix.NewFileLogFactory(appSettings)
+	logFactory := quickfix.NewNullLogFactory()
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	initiator, err := quickfix.NewInitiator(app, appSettings, logFactory)
+	storeFactory := quickfix.NewMemoryStoreFactory()
+
+	initiator, err := quickfix.NewInitiator(app, storeFactory, appSettings, logFactory)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -56,7 +62,7 @@ func main() {
 			field.NewOrdType(enum.OrdType_MARKET))
 
 		quickfix.SendToTarget(order, SessionID)
-		time.Sleep(1 * time.Millisecond)
+		// time.Sleep(1 * time.Millisecond)
 	}
 
 	time.Sleep(2 * time.Second)

--- a/run-inbound-perf.sh
+++ b/run-inbound-perf.sh
@@ -3,11 +3,14 @@
 SAMPLE_SIZE=$1
 [ -z $SAMPLE_SIZE ] && SAMPLE_SIZE=1000
 
-./inbound/inbound -cpuprofile=inbound.prof -fixconfig=cfg/inbound.cfg  -samplesize=$SAMPLE_SIZE &
+# ./inbound/inbound -cpuprofile=inbound.prof -fixconfig=cfg/inbound.cfg  -samplesize=$SAMPLE_SIZE &
+./inbound/inbound -fixconfig=cfg/inbound.cfg  -samplesize=$SAMPLE_SIZE &
 RETVAL=$?
 [ $RETVAL -ne 0 ] && exit $RETVAL
 
 INBOUND_PID=$!
+
+trap "kill $INBOUND_PID" 1 2 3 9 15
 
 ./outbound/outbound -fixconfig=cfg/outbound.cfg -samplesize=$SAMPLE_SIZE 
 RETVAL=$?


### PR DESCRIPTION
A proposed patch fixes compiliation errors due to quickfix-go API change. It also has small improvements in stats output, plus a fix of shell script to avoid hanging due to bad signal handling.
